### PR TITLE
Fix BootJar mainClass configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ subprojects {
     }
 
     tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {
-        mainClass.set("com.receiptgenerator.BootApplication.kt")
+        mainClass.set("com.receiptgenerator.BootApplication")
     }
 
     tasks.withType<Test> {


### PR DESCRIPTION
## Summary
- fix Spring Boot BootJar main class reference

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab97bf819483238e6e36705832c5b7