### PR TITLE
Remove Temporal annotation from Emissor timestamps

### DIFF
--- a/repository/src/main/kotlin/com/receiptgenerator/repository/entity/Emissor.kt
+++ b/repository/src/main/kotlin/com/receiptgenerator/repository/entity/Emissor.kt
@@ -30,12 +30,10 @@ data class Emissor(
     @OneToMany(mappedBy = "emissor", cascade = arrayOf(CascadeType.ALL), orphanRemoval = true)
     val telefone: List<Telefone>? = null,
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "data_criacao", nullable = false)
     @CreatedDate
     val dataCriacao: LocalDateTime = LocalDateTime.now(),
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "data_atualizacao", nullable = false)
     @LastModifiedDate
     val dataAtualizacao: LocalDateTime = LocalDateTime.now()


### PR DESCRIPTION
## Summary
- ensure LocalDateTime timestamps persist without @Temporal

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68ab987a06308323ad970b1361e509a9